### PR TITLE
PJ DAOでバッジNFTを生成できるようにする

### DIFF
--- a/contract/contracts/BadgeNFT.sol
+++ b/contract/contracts/BadgeNFT.sol
@@ -17,7 +17,9 @@ contract BadgeNFT is ERC721, ERC721Enumerable, ERC721URIStorage, ERC721Burnable,
 
     constructor() ERC721("BadgeNFT", "BDG") EIP712("BadgeNFT", "1") {}
 
-    function safeMint(address to, string memory uri) public onlyOwner {
+    // 暫定設定として、PJ DAO側のメンバーが条件が揃えば、Badge NFTのownerでなくてもmintできる仕様
+    // function safeMint(address to, string memory uri) public onlyOwner {
+    function safeMint(address to, string memory uri) public {
         uint256 tokenId = _tokenIdCounter.current();
         _tokenIdCounter.increment();
         _safeMint(to, tokenId);

--- a/contract/contracts/PjDAO.sol
+++ b/contract/contracts/PjDAO.sol
@@ -63,7 +63,7 @@ contract PjDAO {
     }
 
 
-    function mintNftByNftOwner(address _targetAddress) public {
+    function mintNft(address _targetAddress) public {
         ActivityInfo storage info = members[_targetAddress].info;
         require(block.number - info.joinedOrlastMintedBlockAt >= MINT_PERIOD, "The target member has not been enrolled for the specified period");
 

--- a/contract/contracts/PjDAO.sol
+++ b/contract/contracts/PjDAO.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
+import "./BadgeNFT.sol";
+
 contract PjDAO {
     enum PjRole {
         PRODUCTMANAGER,
@@ -10,35 +12,67 @@ contract PjDAO {
         MARKETER
     }
 
+    struct ActivityInfo {
+        uint256 joinedOrlastMintedBlockAt;
+    }
+
     struct Member {
         PjRole role;
+        ActivityInfo info;
     }
 
     mapping(address => Member) public members;
 
     address public owner;
+    address public badgeNftContractAddress;
     string public name;
     string public description;
+
+    uint256 public constant MINT_PERIOD = 300; // 期間 300 ブロック*12 = 3600sec
+    uint256 public constant MINT_AMOUNT = 1; // 発行数 1 枚
+
+    event MemberAdded(address indexed memberAddress, PjRole role);
+    event MemberRemoved(address indexed memberAddress);
+    event NFTMinted(address indexed owner, address indexed memberAddress);
 
     modifier onlyOwner() {
         require(msg.sender == owner, "PjDAO: Only owner can access.");
         _;
     }
 
-    constructor(address _owner, string memory _name, string memory _description) {
+    constructor(address _owner, string memory _name, string memory _description, address _badgeNftContractAddress) {
         owner = _owner;
         name = _name;
         description = _description;
         members[_owner].role = PjRole.PRODUCTMANAGER;
+        badgeNftContractAddress = _badgeNftContractAddress;
     }
 
     function addMember(address _memberAddress, PjRole _role) public onlyOwner {
         require(members[_memberAddress].role == PjRole(0), "PjDAO: Member already exists");
-        members[_memberAddress] = Member(_role);
+        members[_memberAddress] = Member(_role, ActivityInfo(block.number));
+
+        emit MemberAdded(_memberAddress, _role);
     }
 
     function removeMember(address _memberAddress) public onlyOwner {
         require(members[_memberAddress].role != PjRole(0), "PjDAO: Member does not exist");
         delete members[_memberAddress];
+
+        emit MemberRemoved(_memberAddress);
+    }
+
+
+    function mintNftByNftOwner(address _targetAddress) public {
+        ActivityInfo storage info = members[_targetAddress].info;
+        require(block.number - info.joinedOrlastMintedBlockAt >= MINT_PERIOD, "The target member has not been enrolled for the specified period");
+
+        // NFTの発行処理
+        BadgeNFT nftContract = BadgeNFT(badgeNftContractAddress);
+        nftContract.safeMint(_targetAddress, "token_uri");
+        info.joinedOrlastMintedBlockAt = block.number;
+
+        emit NFTMinted(msg.sender, _targetAddress);
+
     }
 }

--- a/contract/contracts/PjDAOFactory.sol
+++ b/contract/contracts/PjDAOFactory.sol
@@ -17,18 +17,20 @@ contract PjDAOFactory {
         string description;
     }
 
-    address public nftContractAddress;
+    address public memberNftContractAddress;
+    address public badgeNftContractAddress;
     PjDAOInfo[] public allPjDAOs;
 
     event PjDAOCreated(address pjDAO, address creator);
 
-    constructor(address _nftContractAddress) {
-        nftContractAddress = _nftContractAddress;
+    constructor(address _memberNftContractAddress, address _badgeNftContractAddress) {
+        memberNftContractAddress = _memberNftContractAddress;
+        badgeNftContractAddress = _badgeNftContractAddress;
     }
 
     function createPjDAO(string memory name, string memory description) public {
         require(
-            IERC721(nftContractAddress).balanceOf(msg.sender) > 0,
+            IERC721(memberNftContractAddress).balanceOf(msg.sender) > 0,
             "Must own NFT to create PjDAO"
         );
 
@@ -41,9 +43,9 @@ contract PjDAOFactory {
             msg.sender
         );
 
-        PjGovernor newPjGovernor = new PjGovernor(IVotes(nftContractAddress), TimelockController(newTimelockController));
+        PjGovernor newPjGovernor = new PjGovernor(IVotes(memberNftContractAddress), TimelockController(newTimelockController));
 
-        PjDAO newPjDAO = new PjDAO(msg.sender, name, description);
+        PjDAO newPjDAO = new PjDAO(msg.sender, name, description, badgeNftContractAddress);
         
         allPjDAOs.push(
             PjDAOInfo({

--- a/contract/scripts/deploy-local.ts
+++ b/contract/scripts/deploy-local.ts
@@ -23,7 +23,7 @@ async function main() {
     console.log("BadgeNFT contract deployed to:", badgeNFT.address);
 
     const PjDAOFactory = await ethers.getContractFactory("PjDAOFactory");
-    const daoFactory = await PjDAOFactory.deploy(memberNFT.address);
+    const daoFactory = await PjDAOFactory.deploy(memberNFT.address, badgeNFT.address);
 
     console.log("PjDAOFactory contract deployed to:", daoFactory.address);
 


### PR DESCRIPTION
### 概要
PJ DAOでバッジNFTを生成できるようにした

- PJ DAOで、NFT生成メソッドの追加、関連変数の設定
- 条件は、参加してから一定ブロック（仮に３００で設定）経過したメンバーがNFT生成できる条件追加
- 関連してFactoryコントラクトの修正
- デプロイスクリプト修正